### PR TITLE
Update Flagsmith to 1.4.1, allow setting traits on identify

### DIFF
--- a/__tests__/useFlagsmith.test.js
+++ b/__tests__/useFlagsmith.test.js
@@ -57,6 +57,16 @@ describe("useFlagsmith", () => {
     expect(result.current.isIdentified).toBeTruthy();
   });
 
+  test("a valid inentify user with traits sets isIdentified to true", async () => {
+    const identify = jest.spyOn(flagsmith, "identify");
+
+    const { result } = renderHook(() => useFlagsmith(), { wrapper });
+
+    await act(() => result.current.identify("user_123", {foo: 'bar'}));
+    expect(identify).toHaveBeenCalledWith("user_123", {foo: 'bar'});
+    expect(result.current.isIdentified).toBeTruthy();
+  })
+
   test("an invalid identify user sets isIdentified to false", async () => {
     const identify = jest
       .spyOn(flagsmith, "identify")

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export interface Flagsmith {
   /**
    * Identify user, triggers a call to get flags if flagsmith.init has been called
    */
-  identify: (userId: string) => Promise<IFlags | undefined>;
+  identify: (userId: string, traits?: Record<string, string|number|boolean>) => Promise<IFlags | undefined>;
 
   /**
    * Clears the identity, triggers a call to getFlags

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "flagsmith-react",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "flagsmith": "^1.2.2",
+        "flagsmith": "^1.4.1",
         "prop-types": "^15.7.2"
       },
       "devDependencies": {
@@ -41,6 +41,9 @@
         "rollup-plugin-serve": "^1.0.1",
         "rollup-plugin-terser": "^7.0.0",
         "rollup-plugin-typescript2": "^0.27.0"
+      },
+      "engines": {
+        "npm": ">7.0.0"
       },
       "peerDependencies": {
         "react": "^16.11.0 || ^17",
@@ -4691,9 +4694,10 @@
       }
     },
     "node_modules/flagsmith": {
-      "version": "1.2.2",
-      "resolved": "https://gfsdeliver.jfrog.io/artifactory/api/npm/npm/flagsmith/-/flagsmith-1.2.2.tgz",
-      "integrity": "sha1-E1CrgzcLAUHYhHwoAi8rguhugCQ="
+      "version": "1.4.1",
+      "resolved": "https://gfsdeliver.jfrog.io/artifactory/api/npm/npm/flagsmith/-/flagsmith-1.4.1.tgz",
+      "integrity": "sha1-EZY/RmN3/FucrSF6qKjRU5wuUGI=",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
@@ -14660,9 +14664,9 @@
       }
     },
     "flagsmith": {
-      "version": "1.2.2",
-      "resolved": "https://gfsdeliver.jfrog.io/artifactory/api/npm/npm/flagsmith/-/flagsmith-1.2.2.tgz",
-      "integrity": "sha1-E1CrgzcLAUHYhHwoAi8rguhugCQ="
+      "version": "1.4.1",
+      "resolved": "https://gfsdeliver.jfrog.io/artifactory/api/npm/npm/flagsmith/-/flagsmith-1.4.1.tgz",
+      "integrity": "sha1-EZY/RmN3/FucrSF6qKjRU5wuUGI="
     },
     "flat-cache": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.11.0 || ^17"
   },
   "dependencies": {
-    "flagsmith": "^1.2.2",
+    "flagsmith": "^1.4.1",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/src/flagsmith-provider.js
+++ b/src/flagsmith-provider.js
@@ -59,10 +59,12 @@ const FlagsmithProvider = ({
   ]);
 
   const identify = useCallback(
-    async (identity) => {
+    async (identity, traits) => {
       let result = undefined;
       try {
-        result = await flagsmith.identify(identity);
+        traits ?
+          result = await flagsmith.identify(identity, traits) :
+          result = await flagsmith.identify(identity);
         dispatch({ type: "IDENTIFIED" });
       } catch {
         dispatch({ type: "UNIDENTIFIED" });


### PR DESCRIPTION
Upgrade Flagsmith package, types, and identify method. Add a test!

closes #24 